### PR TITLE
feat: prevent duplicate AmoCRM leads

### DIFF
--- a/src/infrastructure/redis/redis.service.ts
+++ b/src/infrastructure/redis/redis.service.ts
@@ -73,6 +73,24 @@ export class RedisService implements OnModuleInit {
     await this.client.del(key);
   }
 
+  /**
+   * Acquire a distributed lock.
+   * @returns true if lock was acquired
+   */
+  public async acquireLock(key: string, ttlMs: number): Promise<boolean> {
+    await this.connectIfNeed();
+    const result = await this.client.set(key, '1', { NX: true, PX: ttlMs });
+    return result === 'OK';
+  }
+
+  /**
+   * Release a distributed lock.
+   */
+  public async releaseLock(key: string): Promise<void> {
+    await this.connectIfNeed();
+    await this.client.del(key);
+  }
+
   public async getSetInfo(key: string): Promise<{ exists: boolean; length: number }> {
     await this.connectIfNeed();
 


### PR DESCRIPTION
## Summary
- add Redis-based lock to avoid parallel lead creation
- create AmoCRM leads only when 404 is returned
- expose Redis lock helpers

## Testing
- `npm test`
- `npm run lint` *(fails: A configuration object specifies rule "prettier/prettier", but could not find plugin "prettier".)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda1785048321974a3d5c79a5e210